### PR TITLE
added sctp.h to Makefile.in

### DIFF
--- a/include/dnet/Makefile.in
+++ b/include/dnet/Makefile.in
@@ -106,7 +106,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 dnetincludedir = $(includedir)/dnet
 
 dnetinclude_HEADERS = addr.h arp.h blob.h eth.h fw.h icmp.h intf.h ip.h \
-	ip6.h os.h rand.h route.h tcp.h tun.h udp.h
+	ip6.h os.h rand.h route.h tcp.h tun.h udp.h sctp.h
 
 subdir = include/dnet
 mkinstalldirs = $(SHELL) $(top_srcdir)/config/mkinstalldirs


### PR DESCRIPTION
Fixed broken install by adding `include/dnet/sctp.h`to the manifest in `include/dnet/Makefile.in`
