### PR TITLE
sort linker file list

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -20,7 +20,7 @@ else:
     # XXX - can't build on Cygwin+MinGW yet.
     #if sys.platform == 'cygwin':
     #    dnet_extargs.append('-mno-cygwin')
-    dnet_extobj.extend(glob.glob('@top_builddir@/src/.libs/*.o'))
+    dnet_extobj.extend(sorted(glob.glob('@top_builddir@/src/.libs/*.o')))
 
 dnet = Extension('dnet',
                  dnet_srcs,


### PR DESCRIPTION
so that dnet.so builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This allows the libdnet package in openSUSE Tumbleweed
to produce identical rpms on different builds.