### PR TITLE
Fixed missing sctp.h in include/dnet

### DIFF
--- a/include/dnet/Makefile.in
+++ b/include/dnet/Makefile.in
@@ -106,7 +106,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 dnetincludedir = $(includedir)/dnet
 
 dnetinclude_HEADERS = addr.h arp.h blob.h eth.h fw.h icmp.h intf.h ip.h \
-	ip6.h os.h rand.h route.h tcp.h tun.h udp.h
+	ip6.h os.h rand.h route.h tcp.h tun.h udp.h sctp.h
 
 subdir = include/dnet
 mkinstalldirs = $(SHELL) $(top_srcdir)/config/mkinstalldirs


### PR DESCRIPTION
### Problem
The file `sctp.h` is not installed into the `include/dnet/` directory which causes ` /usr/local/include/dnet.h:22:10: fatal error: dnet/sctp.h: No such file or directory` on `#include <dnet/sctp.h>`

### Context
It appears to be a mistake as Makefile.am contains all headers but Makefile.in is missing `sctp.h`

### Fix
Add `stcp.h` to `dnetinclude_HEADERS`