### PR TITLE
configure: Use AC_CONFIG_HEADERS instead of deprecated AM_CONFIG_HEADER

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_CONFIG_AUX_DIR(config)
 AC_SUBST(ac_aux_dir)
 
 AM_INIT_AUTOMAKE
-AM_CONFIG_HEADER(include/config.h)
+AC_CONFIG_HEADERS(include/config.h)
 
 LT_PREREQ([2.2])
 LT_INIT


### PR DESCRIPTION
AM_CONFIG_HEADER was deprecated a long time ago[0]. Replace it with
AC_CONFIG_HEADERS to make newer versions of autoconf/automake happy.

[0] https://www.gnu.org/software/automake/manual/automake.html#index-AC_005fCONFIG_005fHEADERS