### PR TITLE
python: Include config.h for strlcpy definition

### DIFF
--- a/python/dnet.c
+++ b/python/dnet.c
@@ -22,6 +22,7 @@
 #endif
 __PYX_EXTERN_C double pow(double, double);
 #include "dnet.h"
+#include "config.h"
 
 
 typedef struct {const char *s; const void **p;} __Pyx_CApiTabEntry; /*proto*/


### PR DESCRIPTION
When no definition of strlcpy is found and the local version is used,
compiling python/dnet.c triggers a warning in the preprocessor:

./dnet.c:3649:3: warning: implicit declaration of function ‘strlcpy’;
did you mean ‘strncpy’? [-Wimplicit-function-declaration]

Fix this by including the generated config.h which does define strlcpy.