### PR TITLE
Don't try to convert hostnames to addresses in addr_pton()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 libdnet
 -------
 
-This is a fork of the original libdnet (https://github.com/dugsong/libdnet), since the
-previous author doesn't respon to issues and pull requests.
-We're currently trying to get this in shape (again), address the issues and pull requests,
-available in the original Github repo and eventually will rename this repo (opinions?).
-
-libdnet provides a simplified, portable interface to several low-level
-networking routines, including network address manipulation, kernel
-arp(4) cache and route(4) table lookup and manipulation, network
-firewalling, network interface lookup and manipulation, IP tunnelling,
-and raw IP packet and Ethernet frame transmission.
-
-WWW: https://github.com/ofalk/libdnet
+This is a fork of https://github.com/ofalk/libdnet to address an open issue with addr_pton()
+calling gethostbyname().  This fork just removes the handling of host names as the first
+argument to addr_pton() since it can't do the right thing in a dual-stack world (there is
+no right thing to do; does the user want the AAAA record or the A record?  If there is
+more than one record (even if the same type), which one do we want to use?  etc.
+Basically, keep any resolver calls out of addr.c.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 libdnet
 -------
 
-This is a fork of https://github.com/ofalk/libdnet to address an open issue with addr_pton()
-calling gethostbyname().  This fork just removes the handling of host names as the first
-argument to addr_pton() since it can't do the right thing in a dual-stack world (there is
-no right thing to do; does the user want the AAAA record or the A record?  If there is
-more than one record (even if the same type), which one do we want to use?  etc.
-Basically, keep any resolver calls out of addr.c.
+This is a fork of the original libdnet (https://github.com/dugsong/libdnet), since the
+previous author doesn't respon to issues and pull requests.
+We're currently trying to get this in shape (again), address the issues and pull requests,
+available in the original Github repo and eventually will rename this repo (opinions?).
+
+libdnet provides a simplified, portable interface to several low-level
+networking routines, including network address manipulation, kernel
+arp(4) cache and route(4) table lookup and manipulation, network
+firewalling, network interface lookup and manipulation, IP tunnelling,
+and raw IP packet and Ethernet frame transmission.
+
+WWW: https://github.com/ofalk/libdnet

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is a fork of https://github.com/ofalk/libdnet to address an open issue with
 calling gethostbyname().  This fork just removes the handling of host names as the first
 argument to addr_pton() since it can't do the right thing in a dual-stack world (there is
 no right thing to do; does the user want the AAAA record or the A record?  If there is
-more than one record (even if the same type), which one do we want to use?  etc.).
+more than one record (even if the same type), which one do we want to use?  etc.
 Basically, keep any resolver calls out of addr.c.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This is a fork of https://github.com/ofalk/libdnet to address an open issue with
 calling gethostbyname().  This fork just removes the handling of host names as the first
 argument to addr_pton() since it can't do the right thing in a dual-stack world (there is
 no right thing to do; does the user want the AAAA record or the A record?  If there is
-more than one record (even if the same type), which one do we want to use?  etc.
+more than one record (even if the same type), which one do we want to use?  etc.).
 Basically, keep any resolver calls out of addr.c.

--- a/man/dnet.3
+++ b/man/dnet.3
@@ -262,7 +262,7 @@ and writes it into
 converts an address from network format to a string.
 .Pp
 .Fn addr_pton
-converts an address (or hostname) from a string to network format.
+converts an address from a string to network format.
 .Pp
 .Fn addr_ntoa
 converts an address from network format to a string, returning a

--- a/src/addr.c
+++ b/src/addr.c
@@ -165,7 +165,6 @@ addr_ntop(const struct addr *src, char *dst, size_t size)
 int
 addr_pton(const char *src, struct addr *dst)
 {
-	struct hostent *hp;
 	char *ep, tmp[300];
 	long bits = -1;
 	int i;
@@ -203,10 +202,6 @@ addr_pton(const char *src, struct addr *dst)
 	} else if (ip6_pton(tmp, &dst->addr_ip6) == 0) {
 		dst->addr_type = ADDR_TYPE_IP6;
 		dst->addr_bits = IP6_ADDR_BITS;
-	} else if ((hp = gethostbyname(tmp)) != NULL) {
-		memcpy(&dst->addr_ip, hp->h_addr, IP_ADDR_LEN);
-		dst->addr_type = ADDR_TYPE_IP;
-		dst->addr_bits = IP_ADDR_BITS;
 	} else {
 		errno = EINVAL;
 		return (-1);


### PR DESCRIPTION
addr_pton() should only work on address strings and not call the resolver.  Especially in a dual-stack world where AAAA and A records for the same hostname are very common.