### PR TITLE
Don't try to include bsd/string.h if not present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,13 @@ else
 	    netinet/ip_compat.h ip_fil.h netinet/ip_fil.h)
 	AC_CHECK_HEADERS(hpsecurity.h stropts.h)
 fi
+AC_CHECK_HEADERS(bsd/string.h)
+if test "$ac_cv_header_bsd_string_h" = yes; then
+    STRLCPY_HEADER="bsd/string.h"
+else
+    STRLCPY_HEADER="string.h"
+fi
+AC_SUBST(STRLCPY_HEADER)
 
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
@@ -336,5 +343,6 @@ fi
 
 AC_OUTPUT([Makefile dnet-config include/Makefile include/dnet/Makefile
 	man/Makefile src/Makefile python/Makefile python/setup.py
-	test/Makefile test/check/Makefile test/dnet/Makefile],
+	python/dnet.pxd test/Makefile test/check/Makefile
+	test/dnet/Makefile],
 	[chmod 755 dnet-config])

--- a/python/dnet.pxd.in
+++ b/python/dnet.pxd.in
@@ -1,0 +1,2 @@
+cdef extern from "@STRLCPY_HEADER@":
+    size_t     strlcpy(char *dst, char *src, size_t size)

--- a/python/dnet.pyx
+++ b/python/dnet.pyx
@@ -40,8 +40,7 @@ cdef extern from *:
     unsigned long htonl(unsigned long n)
     unsigned long ntohl(unsigned long n)
 
-cdef extern from "bsd/string.h":
-    int     strlcpy(char *dst, char *src, int size)
+from dnet cimport *
 
 cdef __memcpy(char *dst, object src, int n):
     if PyBytes_Size(src) != n:


### PR DESCRIPTION
Closes #82.

Note that I haven't regenerated configure in this commit because I have a newer version of autoconf than was used previously, so there would be a lot of unrelated changes in the diff.