### PR TITLE
fix payload size of Netlink message in route_get()

### DIFF
--- a/src/route-linux.c
+++ b/src/route-linux.c
@@ -232,7 +232,7 @@ route_get(route_t *r, struct route_entry *entry)
 	memset(buf, 0, sizeof(buf));
 
 	nmsg = (struct nlmsghdr *)buf;
-	nmsg->nlmsg_len = NLMSG_LENGTH(sizeof(*nmsg)) + RTA_LENGTH(alen);
+	nmsg->nlmsg_len = NLMSG_LENGTH(sizeof(*rmsg) + RTA_LENGTH(alen));
 	nmsg->nlmsg_flags = NLM_F_REQUEST;
 	nmsg->nlmsg_type = RTM_GETROUTE;
 	nmsg->nlmsg_seq = ++seq;


### PR DESCRIPTION
The `len` parameter of `NLMSG_LENGTH`  was size of Netlink header instead of RtNetlink header.

Also make it more clear that the parameter of the macro is the payload size, which is RtNetlink message in this case.