### PR TITLE
Update icmp.h

### DIFF
--- a/include/dnet/icmp.h
+++ b/include/dnet/icmp.h
@@ -164,8 +164,8 @@ struct icmp_msg_tstamp {
  * Address mask message data, RFC 950
  */
 struct icmp_msg_mask {
-	uint32_t	icmp_id;		/* identifier */
-	uint32_t	icmp_seq;		/* sequence number */
+	uint16_t	icmp_id;		/* identifier */
+	uint16_t	icmp_seq;		/* sequence number */
 	uint32_t	icmp_mask;		/* address mask */
 };
 


### PR DESCRIPTION
here too the fields are incorrectly sized, you can understand even by the htons function in the icmp_pack_hdr_mask macro.