### PR TITLE
config.h.in: Fix wrong return type

### DIFF
--- a/include/config.h.in
+++ b/include/config.h.in
@@ -293,11 +293,11 @@ int inet_pton(int, const char *, void *);
 #endif
 
 #ifndef HAVE_STRLCAT
-int strlcat(char *, const char *, int);
+size_t strlcat(char *, const char *, int);
 #endif
 
 #ifndef HAVE_STRLCPY
-int strlcpy(char *, const char *, int);
+size_t strlcpy(char *, const char *, int);
 #endif
 
 #ifndef HAVE_STRSEP


### PR DESCRIPTION
The strlcpy and strlcat are documented as returning size_t, not int. If there should be duplicated definitions in the libdnet sources (why?) these  should match this, current code does not compile on all platforms due to conflicts with headers in /usr/include

EDIT: obviously related to #95